### PR TITLE
preg_replace_callback returns null

### DIFF
--- a/LinkTitles.body.php
+++ b/LinkTitles.body.php
@@ -213,7 +213,7 @@
 				// the title has to be searched for either in a strictly case-sensitive
 				// way, or in a 'fuzzy' way where the first letter of the title may
 				// be either case.
-				if ( $wgCapitalLinks && ( $quotedTitle[0] != '\\' )) {
+				if ( $wgCapitalLinks && ( $quotedTitle[0] != '\\' ) && (1 == preg_match('/[a-zA-Z]/',$quotedTitle[0])) {
 					$searchTerm = '((?i)' . $quotedTitle[0] . '(?-i)' . 
 						substr($quotedTitle, 1) . ')';
 				}	else {


### PR DESCRIPTION
Hello. I'm sorry I cannot understand Germany.

Thank you for great extension. But I found a error when we use this in Japanese Environment.
In certain case, preg_replace_callback returns null, and result of parseContent function will be empty.
I think page_title that starts with certain multi-byte character will cause this bug around "(?i) (?i-1)" search term.

So I added check if the first letter of title is one of alphabet.
Please check it.
