### PR TITLE
Cache page titles.

### DIFF
--- a/includes/LinkTitles_Extension.php
+++ b/includes/LinkTitles_Extension.php
@@ -141,6 +141,9 @@ class Extension {
 		foreach( self::$pageTitles as $row ) {
 			self::newTarget( $row->page_namespace, $row->page_title );
 
+			// Don't link current page
+			if ( self::$targetTitle->equals( self::$currentTitle ) ) { continue; }
+
 			// split the page content by [[...]] groups
 			// credits to inhan @ StackOverflow for suggesting preg_split
 			// see http://stackoverflow.com/questions/10672286
@@ -253,9 +256,7 @@ class Extension {
 		( $wgLinkTitlesPreferShortTitles ) ? $sort_order = 'ASC' : $sort_order = 'DESC';
 		// Build a blacklist of pages that are not supposed to be link 
 		// targets. This includes the current page.
-		$blackList = str_replace( ' ', '_',
-			'("' . implode( '","',$wgLinkTitlesBlackList ) . '","' .
-			addslashes( self::$currentTitle->getDbKey() ) . '")' );
+		$blackList = str_replace( ' ', '_', '("' . implode( '","',$wgLinkTitlesBlackList ) . '")' );
 
 		// Build our weight list. Make sure current namespace is first element
 		$namespaces = array_diff( $wgLinkTitlesNamespaces, [ $currentNamespace ] );


### PR DESCRIPTION
This is an attempt to increase performance of the special page and the maintenance script by caching the page titles that are fetched from the database.

On my development machine with a very small wiki, this led to a very small performance impact. However, the difference in execution time approaches statistical significance as I increase the number of runs.

These are the 'real' times of `time php LinkTitles_Maintenance.php` in milliseconds:

		old	new
	1	1124	900
	2	990	1024
	3	963	890
	4	937	914
	5	1000	935
	6	922	1040
	7	991	942
	8	1000	909
	9	987	932
	10	1071	1032
		
	mean	998.5	951.8
	sd	59.78	57.69
		
	ttest	0.09	

