### PR TITLE
Add $wgLinkTitlesSameNamespaceOnly option

### DIFF
--- a/includes/LinkTitles_Extension.php
+++ b/includes/LinkTitles_Extension.php
@@ -254,15 +254,20 @@ class Extension {
 		global $wgLinkTitlesMinimumTitleLength;
 		global $wgLinkTitlesBlackList;
 		global $wgLinkTitlesNamespaces;
+		global $wgLinkTitlesSameNamespaceOnly;
 
 		( $wgLinkTitlesPreferShortTitles ) ? $sort_order = 'ASC' : $sort_order = 'DESC';
 		// Build a blacklist of pages that are not supposed to be link
 		// targets. This includes the current page.
 		$blackList = str_replace( ' ', '_', '("' . implode( '","',$wgLinkTitlesBlackList ) . '")' );
 
-		// Build our weight list. Make sure current namespace is first element
-		$namespaces = array_diff( $wgLinkTitlesNamespaces, [ $currentNamespace ] );
-		array_unshift( $namespaces,  $currentNamespace );
+		if (isset($wgLinkTitlesSameNamespaceOnly) && $wgLinkTitlesSameNamespaceOnly) {
+			$namespaces = [ $currentNamespace ];
+		} else {
+			// Build our weight list. Make sure current namespace is first element
+			$namespaces = array_diff( $wgLinkTitlesNamespaces, [ $currentNamespace ] );
+			array_unshift( $namespaces,  $currentNamespace );
+		}
 
 		// No need for sanitiy check. we are sure that we have at least one element in the array
 		$weightSelect = "CASE page_namespace ";


### PR DESCRIPTION
I create a global variable named $wgLinkTitlesSameNamespaceOnly.
When the variable is true, this plugin doesn't make the link to page belonging to different namespace.

use case:
I made namespaces named "Japanese " and" English" at my wiki.
And I created pages below.

* Japanese:Memo
* English:Memo
* Japanese:Wiki
* English:Wiki

I want links from Japanese:Memo to Japanese:Wiki, but I don't want link from Japanese:Memo to English:Memo.