### PR TITLE
Replace PageContentSave with MultiContentSave

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ For changes prior to version 6.0.0, please see [`NEWS.old`](news.old).
 
 ### Fixed
 
-- Fixed compatibility with MediaWiki version 1.35+.
+- Replace PageContentSave with MultiContentSave to fix compatibility with MediaWiki 1.35.
 
 ## [7.0.0][] - 2020-12-23
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For changes prior to version 6.0.0, please see [`NEWS.old`](news.old).
 
+## [7.1.0][] - 2021-03-21
+
+### Changed
+
+- The minimum required version of MediaWiki is now 1.35.
+
+### Fixed
+
+- Fixed compatibility with MediaWiki version 1.35+.
+
 ## [7.0.0][] - 2020-12-23
 
 ### Changed

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@ For changes prior to version 6.0.0, please see [`NEWS.old`](news.old).
 ### Fixed
 
 - Replace PageContentSave with MultiContentSave to fix compatibility with MediaWiki 1.35.
+- The default value for wgLinkTitlesParseOnRender is change back to `false` as support
+  for MediaWiki 1.35+ is fixed.
 
 ## [7.0.0][] - 2020-12-23
 

--- a/extension.json
+++ b/extension.json
@@ -15,7 +15,7 @@
         "license-name": "GPL-2.0+",
         "descriptionmsg": "linktitles-desc",
         "requires": {
-                "MediaWiki": ">= 1.32.0"
+                "MediaWiki": ">= 1.35.0"
         },
         "config": {
                 "LinkTitlesParseOnEdit": true,
@@ -61,9 +61,6 @@
         "Hooks": {
                 "MultiContentSave": [
                         "LinkTitles\\Extension::onMultiContentSave"
-                ],
-                "PageContentSave": [
-                        "LinkTitles\\Extension::onPageContentSave"
                 ],
                 "InternalParseBeforeLinks": [
                         "LinkTitles\\Extension::onInternalParseBeforeLinks"

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
         ],
         "type": "parserhook",
         "url": "https://www.mediawiki.org/wiki/Extension:LinkTitles",
-        "version": "6.0.0",
+        "version": "6.1.0",
         "license-name": "GPL-2.0+",
         "descriptionmsg": "linktitles-desc",
         "requires": {

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
         ],
         "type": "parserhook",
         "url": "https://www.mediawiki.org/wiki/Extension:LinkTitles",
-        "version": "6.1.0",
+        "version": "7.1.0",
         "license-name": "GPL-2.0+",
         "descriptionmsg": "linktitles-desc",
         "requires": {

--- a/extension.json
+++ b/extension.json
@@ -19,7 +19,7 @@
         },
         "config": {
                 "LinkTitlesParseOnEdit": true,
-                "LinkTitlesParseOnRender": true,
+                "LinkTitlesParseOnRender": false,
                 "LinkTitlesParseHeadings": false,
                 "LinkTitlesSkipTemplates": true,
                 "LinkTitlesPreferShortTitles": true,

--- a/extension.json
+++ b/extension.json
@@ -59,6 +59,9 @@
                 }
         },
         "Hooks": {
+                "MultiContentSave": [
+                        "LinkTitles\\Extension::onMultiContentSave"
+                ],
                 "PageContentSave": [
                         "LinkTitles\\Extension::onPageContentSave"
                 ],

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -44,26 +44,26 @@ class Extension {
 	 * This handler is used if the parseOnEdit configuration option is set.
 	 */
 	public static function onMultiContentSave( RenderedRevision $renderedRevision, User $user, CommentStoreComment $summary, $flags, Status $hookStatus ) {
-                $config = new Config();
-                if ( !$config->parseOnEdit ) return true;
+		$config = new Config();
+		if ( !$config->parseOnEdit ) return true;
 		$title = $renderedRevision->getRevision()->getPageAsLinkTarget();
 		$slots = $renderedRevision->getRevision()->getSlots();
-                $content = $renderedRevision->getRevision()->getSlots()->getContent( SlotRecord::MAIN );
-                $articleID = $renderedRevision->getRevision()->getPageId();
-                $wikiPage = WikiPage::newFromID( $articleID );
+		$content = $renderedRevision->getRevision()->getSlots()->getContent( SlotRecord::MAIN );
+		$articleID = $renderedRevision->getRevision()->getPageId();
+		$wikiPage = WikiPage::newFromID( $articleID );
 		if ( $wikiPage == null ) {
 			return true;
 		}
-                $source = Source::createFromPageandContent( $wikiPage, $content, $config );
-                $linker = new Linker( $config );
-                $result = $linker->linkContent( $source );
-                if ( $result ) {
-                        $source->setText( $result );
+		$source = Source::createFromPageandContent( $wikiPage, $content, $config );
+		$linker = new Linker( $config );
+		$result = $linker->linkContent( $source );
+		if ( $result ) {
+			$source->setText( $result );
 
-                        $text = $source->getText($result);
+			$text = $source->getText($result);
 			$slots = $renderedRevision->getRevision()->getSlots();
-                        $slots->setContent( 'main', ContentHandler::makeContent( $text, $title ) );
-                }
+			$slots->setContent( 'main', ContentHandler::makeContent( $text, $title ) );
+		}
 
 		return true;
 	}

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -25,7 +25,6 @@
 namespace LinkTitles;
 
 use CommentStoreComment;
-use ContentHandler;
 use MediaWiki\Revision\RenderedRevision;
 use MediaWiki\Revision\SlotRecord;
 use Status;
@@ -43,11 +42,18 @@ class Extension {
 	 *
 	 * This handler is used if the parseOnEdit configuration option is set.
 	 */
-	public static function onMultiContentSave( RenderedRevision $renderedRevision, User $user, CommentStoreComment $summary, $flags, Status $hookStatus ) {
+	public static function onMultiContentSave(
+		RenderedRevision $renderedRevision,
+		User $user,
+		CommentStoreComment $summary,
+		$flags,
+		Status $hookStatus
+	) {
 		$config = new Config();
 		if ( !$config->parseOnEdit ) return true;
-		
+
 		$revision = $renderedRevision->getRevision();
+		$title = $revision->getPageAsLinkTarget();
 		$slots = $revision->getSlots();
 		$content = $slots->getContent( SlotRecord::MAIN );
 

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -52,7 +52,7 @@ class Extension {
 		$isMinor = $flags & EDIT_MINOR;
 
 		$config = new Config();
-		if ( !$config->parseOnEdit && $isMinor ) return true;
+		if ( !$config->parseOnEdit || $isMinor ) return true;
 
 		$revision = $renderedRevision->getRevision();
 		$title = $revision->getPageAsLinkTarget();

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -46,23 +46,18 @@ class Extension {
 	public static function onMultiContentSave( RenderedRevision $renderedRevision, User $user, CommentStoreComment $summary, $flags, Status $hookStatus ) {
 		$config = new Config();
 		if ( !$config->parseOnEdit ) return true;
-		$title = $renderedRevision->getRevision()->getPageAsLinkTarget();
-		$slots = $renderedRevision->getRevision()->getSlots();
-		$content = $renderedRevision->getRevision()->getSlots()->getContent( SlotRecord::MAIN );
-		$articleID = $renderedRevision->getRevision()->getPageId();
-		$wikiPage = WikiPage::newFromID( $articleID );
-		if ( $wikiPage == null ) {
-			return true;
-		}
+		
+		$revision = $renderedRevision->getRevision();
+		$slots = $revision->getSlots();
+		$content = $slots->getContent( SlotRecord::MAIN );
+
+		$wikiPage = WikiPage::factory( $title );
 		$source = Source::createFromPageandContent( $wikiPage, $content, $config );
 		$linker = new Linker( $config );
 		$result = $linker->linkContent( $source );
 		if ( $result ) {
-			$source->setText( $result );
-
-			$text = $source->getText($result);
-			$slots = $renderedRevision->getRevision()->getSlots();
-			$slots->setContent( 'main', ContentHandler::makeContent( $text, $title ) );
+			$content = $source->setText( $result );
+			$slots->setContent( 'main', $content );
 		}
 
 		return true;

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -76,6 +76,14 @@ class Extension {
 	 */
 	public static function onPageContentSave( &$wikiPage, &$user, &$content, &$summary,
 			$isMinor, $isWatch, $section, &$flags, &$status ) {
+		global $wgVersion;
+
+		if ( version_compare( $wgVersion, '1.35', '>=' ) ) {
+			// This hook is deprecated and does not work as intended on MW 1.32+.
+			// Instead we use onMultiContentSave which works from 1.35+.
+			return true;
+		}
+
 		$config = new Config();
 		if ( !$config->parseOnEdit || $isMinor ) return true;
 		$source = Source::createFromPageandContent( $wikiPage, $content, $config );

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -49,8 +49,10 @@ class Extension {
 		$flags,
 		Status $hookStatus
 	) {
+		$isMinor = $flags & EDIT_MINOR;
+
 		$config = new Config();
-		if ( !$config->parseOnEdit ) return true;
+		if ( !$config->parseOnEdit && $isMinor ) return true;
 
 		$revision = $renderedRevision->getRevision();
 		$title = $revision->getPageAsLinkTarget();

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -69,32 +69,6 @@ class Extension {
 		return true;
 	}
 
-	/**
-	 * Event handler for the PageContentSave hook.
-	 *
-	 * This handler is used if the parseOnEdit configuration option is set.
-	 */
-	public static function onPageContentSave( &$wikiPage, &$user, &$content, &$summary,
-			$isMinor, $isWatch, $section, &$flags, &$status ) {
-		global $wgVersion;
-
-		if ( version_compare( $wgVersion, '1.35', '>=' ) ) {
-			// This hook is deprecated and does not work as intended on MW 1.32+.
-			// Instead we use MultiContentSave which works from 1.35+.
-			return true;
-		}
-
-		$config = new Config();
-		if ( !$config->parseOnEdit || $isMinor ) return true;
-		$source = Source::createFromPageandContent( $wikiPage, $content, $config );
-		$linker = new Linker( $config );
-		$result = $linker->linkContent( $source );
-		if ( $result ) {
-			$content = $source->setText( $result );
-		}
-		return true;
-	}
-
 	/*
 	 * Event handler for the InternalParseBeforeLinks hook.
 	 *

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -25,6 +25,7 @@
 namespace LinkTitles;
 
 use CommentStoreComment;
+use ContentHandler;
 use MediaWiki\Revision\RenderedRevision;
 use MediaWiki\Revision\SlotRecord;
 use Status;
@@ -50,6 +51,9 @@ class Extension {
                 $content = $renderedRevision->getRevision()->getSlots()->getContent( SlotRecord::MAIN );
                 $articleID = $renderedRevision->getRevision()->getPageId();
                 $wikiPage = WikiPage::newFromID( $articleID );
+		if ( $wikiPage == null ) {
+			return true;
+		}
                 $source = Source::createFromPageandContent( $wikiPage, $content, $config );
                 $linker = new Linker( $config );
                 $result = $linker->linkContent( $source );
@@ -58,7 +62,7 @@ class Extension {
 
                         $text = $source->getText($result);
 			$slots = $renderedRevision->getRevision()->getSlots();
-                        $slots->setContent( 'main', \ContentHandler::makeContent( $text, $title ) );
+                        $slots->setContent( 'main', ContentHandler::makeContent( $text, $title ) );
                 }
 
 		return true;

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -80,7 +80,7 @@ class Extension {
 
 		if ( version_compare( $wgVersion, '1.35', '>=' ) ) {
 			// This hook is deprecated and does not work as intended on MW 1.32+.
-			// Instead we use onMultiContentSave which works from 1.35+.
+			// Instead we use MultiContentSave which works from 1.35+.
 			return true;
 		}
 


### PR DESCRIPTION
PageContentSave is deprecated and does not work the way we want it to under 1.32. So we replace PageContentSave with MultiContentSave which fixes it so it now works but only under 1.35+ as that's when the hook is available from. PageContentSave was basically not working for this extension as it already required 1.32. So we're safe to replace it.

Fixes #43
