### PR TITLE
Fixed an issue that would make LinkTitles cut words in the middle if they had accentuated characters

### DIFF
--- a/includes/Target.php
+++ b/includes/Target.php
@@ -159,7 +159,7 @@ class Target {
 	 * @return String regular expression pattern
 	 */
 	private function buildRegex( $searchTerm ) {
-		return '/(?<![\:\.\@\/\?\&])' . $this->wordStart . $searchTerm . $this->wordEnd . '/S';
+		return '/(?<![\:\.\@\/\?\&])' . $this->wordStart . $searchTerm . $this->wordEnd . '/Su';
 	}
 
 	/**


### PR DESCRIPTION
Here is the result of LinkTitle on a text with an accent: 

`
Les plantes carencées présentent des symptômes caractéristiques tels que des '''chloroses, des dé[[formations]] ou des nécroses d'organes''' qu'il faut observer avec méthode :
`

As you can see, the word has been cut in the middle of it. With the proposed fix the problem disappear.