### PR TITLE
Fix for new MediaWiki\Title\Title

### DIFF
--- a/includes/Targets.php
+++ b/includes/Targets.php
@@ -24,6 +24,8 @@
  */
 namespace LinkTitles;
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * Fetches potential target page titles from the database.
  */
@@ -135,7 +137,7 @@ class Targets {
 		// shortest to longest. Only titles from 'normal' pages (namespace uid
 		// = 0) are returned. Since the db may be sqlite, we need a try..catch
 		// structure because sqlite does not support the CHAR_LENGTH function.
-		$dbr = wfGetDB( DB_REPLICA );
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );
 		$this->queryResult = $dbr->select(
 			'page',
 			array( 'page_title', 'page_namespace' , "weight" => $weightSelect),


### PR DESCRIPTION
I was getting this error:
 TypeError: LinkTitles\Targets::singleton(): Argument #1 ($title) must be of type Title, MediaWiki\Title\Title given, called in /var/www/html/extensions/LinkTitles/includes/Linker.php on line 83.

This was happening after updating to Mediawiki release REL1_44.

This fix replaces the old \Title references with the new \MediaWiki\Title\Title.