### PR TITLE
Fix for new MediaWiki\Title\Title 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 # This Dockerfile can be used to create a Docker image/container
 # that runs the unit tests on the LinkTitles extension.
-FROM mediawiki:1.37
+FROM mediawiki:1.44
 LABEL "MAINTAINER" Daniel Kraus (https://www.bovender.de)
+
 RUN apt-get update -yqq && \
 	apt-get install -yqq \
-	php7.4-sqlite \
 	sqlite3 \
 	unzip \
 	zip
 
 WORKDIR /var/www/html
 ADD install-composer.sh install-composer.sh
+RUN sed -i 's/\r$//' install-composer.sh
 RUN chmod +x install-composer.sh
 RUN ./install-composer.sh
 

--- a/extension.json
+++ b/extension.json
@@ -39,6 +39,9 @@
                 "LinkTitlesTargetNamespaces": [],
                 "LinkTitlesSameNamespace": true
         },
+        "AutoloadNamespaces": {
+                "LinkTitles\\": "includes/"
+        },
         "AutoloadClasses": {
                 "LinkTitles\\Extension": "includes/Extension.php",
                 "LinkTitles\\Linker": "includes/Linker.php",

--- a/includes/Extension.php
+++ b/includes/Extension.php
@@ -29,6 +29,7 @@ use CommentStoreComment;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RenderedRevision;
 use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Title\Title as MWTitle;
 use Status;
 use WikiPage;
 use User;
@@ -64,7 +65,7 @@ class Extension {
 		// MW 1.36+
 		if ( method_exists( MediaWikiServices::class, 'getWikiPageFactory' ) ) {
 			$wikiPageFactory = MediaWikiServices::getInstance()->getWikiPageFactory();
-			$wikiPage = $wikiPageFactory->newFromTitle( $title );
+			$wikiPage = $wikiPageFactory->newFromLinkTarget( $title );
 		} else {
 			$wikiPage = WikiPage::factory( $title );
 		}
@@ -102,11 +103,11 @@ class Extension {
 	 *
 	 * Entry point for the SpecialLinkTitles class and the LinkTitlesJob class.
 	 *
-	 * @param  \Title $title Title object.
+	 * @param  MWTitle $title MWTitle object.
 	 * @param  \RequestContext $context Current request context. If in doubt, call MediaWiki's `RequestContext::getMain()` to obtain such an object.
 	 * @return bool True if the page exists, false if the page does not exist
 	 */
-	public static function processPage( \Title $title, \RequestContext $context ) {
+	public static function processPage( MWTitle $title, \RequestContext $context ) {
 		$config = new Config();
 		$source = Source::createFromTitle( $title, $config );
 		if ( $source->hasContent() ) {

--- a/includes/Linker.php
+++ b/includes/Linker.php
@@ -24,6 +24,8 @@
  */
 namespace LinkTitles;
 
+use MediaWiki\Title\Title as MWTitle;
+
 /**
  * Performs the actual linking of content to existing pages.
  */
@@ -61,12 +63,12 @@ class Linker {
 	/**
 	 * Core function of the extension, performs the actual parsing of the content.
 	 *
-	 * This method receives a Title object and the string representation of the
+	 * This method receives a MWTitle object and the string representation of the
 	 * source page. It does not work on a WikiPage object directly because the
 	 * callbacks in the Extension class do not always get a WikiPage object in the
 	 * first place.
 	 *
-	 * @param \Title &$title Title object for the current page.
+	 * @param MWTitle &$title MWTitle object for the current page.
 	 * @param String $text String that holds the article content
 	 * @return String|null Source page text with links to target pages, or null if no links were added
 	 */

--- a/includes/Source.php
+++ b/includes/Source.php
@@ -25,6 +25,7 @@
 namespace LinkTitles;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title as MWTitle;
 
 /**
  * Represents a page that is a potential link target.
@@ -46,11 +47,11 @@ class Source {
 	private $content;
 
 	/**
-	 * Creates a Source object from a \Title.
-	 * @param  \Title  $title  Title object from which to create the Source.
+	 * Creates a Source object from a Title.
+	 * @param  MWTitle  $title  MWTitle object from which to create the Source.
 	 * @return Source          Source object created from the title.
 	 */
-	public static function createFromTitle( \Title $title, Config $config ) {
+	public static function createFromTitle( MWTitle $title, Config $config ) {
 		$source = new Source( $config );
 		$source->title = $title;
 		return $source;
@@ -62,12 +63,12 @@ class Source {
 	 * This factory can be called e.g. from a onPageContentSave event handler
 	 * which knows both these parameters.
 	 *
-	 * @param  \Title $title Title of the source page
+	 * @param  MWTitle $title MWTitle of the source page
 	 * @param  String $text  String representation of the page content
 	 * @param  Config    $config   LinkTitles configuration
 	 * @return Source        Source object created from the title and the text
 	 */
-	public static function createFromTitleAndText( \Title $title, $text, Config $config ) {
+	public static function createFromTitleAndText( MWTitle $title, $text, Config $config ) {
 		$source = Source::createFromTitle( $title, $config);
 		$source->text = $text;
 		return $source;
@@ -158,7 +159,7 @@ class Source {
 	/**
 	 * Gets the title.
 	 *
-	 * @return \Title Title of the source page.
+	 * @return MWTitle MWTitle of the source page.
 	 */
 	public function getTitle() {
 		if ( $this->title === null ) {
@@ -249,7 +250,7 @@ class Source {
 	/**
  	 * Obtain a WikiPage object.
 	 * Workaround for MediaWiki 1.36+ which deprecated Wikipage::factory.
-	 * @param \Title $title
+	 * @param MWTitle $title
 	 * @return WikiPage object
 	 */
 	private static function getPageObject( $title ) {

--- a/includes/Target.php
+++ b/includes/Target.php
@@ -25,14 +25,15 @@
 namespace LinkTitles;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title as MWTitle;
 
 /**
  * Represents a page that is a potential link target.
  */
 class Target {
 	/**
-	 * A Title object for the target page currently being examined.
-	 * @var \Title $title
+	 * A MWTitle object for the target page currently being examined.
+	 * @var MWTitle $title
 	 */
 	private $title;
 
@@ -76,7 +77,7 @@ class Target {
 	 * @param String &$title Title of the target page
 	 */
 	public function __construct( $namespace, $title, Config &$config ) {
-		$this->title = \Title::makeTitleSafe( $namespace, $title );
+		$this->title = MWTitle::makeTitleSafe( $namespace, $title );
 		$this->titleValue = $this->title->getTitleValue();
 		$this->config = $config;
 
@@ -252,7 +253,7 @@ class Target {
 	/**
  	 * Obtain a page's content.
 	 * Workaround for MediaWiki 1.36+ which deprecated Wikipage::factory.
-	 * @param  \Title $title
+	 * @param  MWTitle $title
 	 * @return Content content object of the page
 	 */
 	private static function getPageContents( $title ) {

--- a/includes/Targets.php
+++ b/includes/Targets.php
@@ -24,6 +24,8 @@
  */
 namespace LinkTitles;
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * Fetches potential target page titles from the database.
  */
@@ -135,7 +137,7 @@ class Targets {
 		// shortest to longest. Only titles from 'normal' pages (namespace uid
 		// = 0) are returned. Since the db may be sqlite, we need a try..catch
 		// structure because sqlite does not support the CHAR_LENGTH function.
-		$dbr = wfGetDB( DB_REPLICA );
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );
 		$this->queryResult = $dbr->select(
 			'page',
 			array( 'page_title', 'page_namespace' , "weight" => $weightSelect),

--- a/includes/Targets.php
+++ b/includes/Targets.php
@@ -24,6 +24,7 @@
  */
 namespace LinkTitles;
 
+use MediaWiki\Title\Title as MWTitle;
 use MediaWiki\MediaWikiServices;
 
 /**
@@ -43,7 +44,7 @@ class Targets {
 	 * @param  String $sourceNamespace The namespace of the current page.
 	 * @param  Config $config    LinkTitles configuration.
 	 */
-	public static function singleton( \Title $title, Config $config ) {
+	public static function singleton( MWTitle $title, Config $config ) {
 		if ( ( self::$instance === null ) || ( self::$instance->sourceNamespace != $title->getNamespace() ) ) {
 			self::$instance = new Targets( $title, $config );
 		}
@@ -85,9 +86,9 @@ class Targets {
 
 	/**
 	 * The constructor is private to enforce using the singleton pattern.
-	 * @param  \Title $title
+	 * @param MWTitle $title
 	 */
-	private function __construct( \Title $title, Config $config) {
+	private function __construct( MWTitle $title, Config $config) {
 		$this->config = $config;
 		$this->sourceNamespace = $title->getNamespace();
 		$this->fetch();

--- a/install-composer.sh
+++ b/install-composer.sh
@@ -16,7 +16,7 @@ then
 fi
 
 # May need to remove the explicit pinning of version 1 in the future
-php composer-setup.php --quiet --1
+php composer-setup.php --quiet
 RESULT=$?
 rm composer-setup.php
 exit $RESULT

--- a/linktitles-cli.php
+++ b/linktitles-cli.php
@@ -23,6 +23,8 @@
  */
 namespace LinkTitles;
 
+use MediaWiki\Title\Title;
+
 // Attempt to include the maintenance base class from:
 //   $wgScriptPath/maintenance/Maintenance.php
 // Our script is normally located at:
@@ -143,7 +145,7 @@ class Cli extends \Maintenance {
 	private function singlePage() {
 		$pageName = strval( $this->getOption( 'page' ) );
 		$this->output( "Processing single page: '$pageName'\n" );
-		$title = \Title::newFromText( $pageName );
+		$title = Title::newFromText( $pageName );
 		$success = Extension::processPage( $title, \RequestContext::getMain() );
 		if ( $success ) {
 			$this->output( "Finished.\n" );
@@ -184,7 +186,7 @@ class Cli extends \Maintenance {
 
 		$numProcessed = 0;
 		foreach ( $res as $row ) {
-			$title = \Title::makeTitleSafe( $row->page_namespace, $row->page_title );
+			$title = Title::makeTitleSafe( $row->page_namespace, $row->page_title );
 			$numProcessed += 1;
 			$index += 1;
 			if ( $verbose ) {

--- a/tests/phpunit/ExtensionTest.php
+++ b/tests/phpunit/ExtensionTest.php
@@ -25,6 +25,11 @@
  * @group bovender
  * @group Database
  */
+
+use MediaWiki\Title\Title;
+use MediaWiki\Page\WikiPageFactory;
+use MediaWiki\MediaWikiServices;
+
 class ExtensionTest extends LinkTitles\TestCase {
 
 	/**
@@ -36,7 +41,9 @@ class ExtensionTest extends LinkTitles\TestCase {
 			'wgLinkTitlesParseOnRender' => !$parseOnEdit
 		] );
 		$pageId = $this->insertPage( 'test page', $input )['id'];
-		$page = WikiPage::newFromId( $pageId );
+		$title = Title::newFromID( $pageId );
+		$wpf = MediaWikiServices::getInstance()->getWikiPageFactory();
+		$page = $wpf->newFromTitle( $title );
 		$this->assertSame( $expectedOutput, self::getPageText( $page ) );
 	}
 
@@ -71,9 +78,10 @@ class ExtensionTest extends LinkTitles\TestCase {
 		] );
 		$title = $this->insertPage( 'test page', $input )['title'];
 		$page = new WikiPage( $title );
-		$user = MediaWiki\User\UserFactory::newAnonymous();
+		$userFactory = MediaWikiServices::getInstance()->getUserFactory();
+		$user = $userFactory->newAnonymous();
 		$output = $page->getParserOutput( new ParserOptions( $user ), null, true );
-		$lines = explode( "\n", $output->getText() );
+		$lines = explode( "\n", $output->getRawText() );
 		$this->assertRegexp( $expectedOutput, $lines[0] );
 	}
 

--- a/tests/phpunit/LinkerTest.php
+++ b/tests/phpunit/LinkerTest.php
@@ -35,6 +35,9 @@
  * @group bovender
  * @group Database
  */
+
+use MediaWiki\MediaWikiServices;
+
 class LinkTitlesLinkerTest extends LinkTitles\TestCase {
 	protected $title;
 
@@ -317,10 +320,11 @@ class LinkTitlesLinkerTest extends LinkTitles\TestCase {
 
 		// Reset namespace caches.
 		// See https://stackoverflow.com/q/45974979/270712
-		\MWNamespace::getCanonicalNamespaces(true);
+		$namespaceInfo = MediaWikiServices::getInstance()->getNamespaceInfo();
+		$namespaceInfo->getCanonicalNamespaces( true );
 		$wgContLang = \MediaWiki\MediaWikiServices::getInstance()->getContentLanguage();
 		$wgContLang->resetNamespaces();
-		$this->assertTrue( MWNamespace::exists( $ns ), "The namespace with id $ns should exist!" );
+		$this->assertTrue( $namespaceInfo->exists( $ns ), "The namespace with id $ns should exist!" );
 
 		$this->insertPage( "in custom namespace", 'This is a page in a custom namespace', $ns );
 		LinkTitles\Targets::invalidate();

--- a/tests/phpunit/SplitterTest.php
+++ b/tests/phpunit/SplitterTest.php
@@ -26,8 +26,8 @@
  *
  * @group bovender
  */
-class SplitterTest extends \MediaWikiTestCase
-{
+
+class SplitterTest extends LinkTitles\TestCase {
 	/**
 	 * @dataProvider provideSplitData
 	 */

--- a/tests/phpunit/TargetTest.php
+++ b/tests/phpunit/TargetTest.php
@@ -24,8 +24,8 @@
 /**
  * @group bovender
  */
-class TargetTest extends \MediaWikiTestCase
-{
+
+class TargetTest extends LinkTitles\TestCase {
 
 	/**
 	 * @dataProvider provideStartOnly

--- a/tests/phpunit/TargetsTest.php
+++ b/tests/phpunit/TargetsTest.php
@@ -36,7 +36,7 @@ class TargetsTest extends LinkTitles\TestCase {
 		// LinkTitlesLinkerTest::testLinkContentTargetNamespaces() is every changed,
 		// this test will fail.
 		$config->targetNamespaces = [ 4000 ];
-		$title = \Title::newFromText( 'link target' );
+		$title = Title::newFromText( 'link target' );
 		$targets = LinkTitles\Targets::singleton( $title, $config );
 
 		// Count number of articles: Inspired by updateArticleCount.php maintenance

--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -21,8 +21,9 @@
  * @author Daniel Kraus <bovender@bovender.de>
  */
 namespace LinkTitles;
+use MediaWikiIntegrationTestCase;
 
-abstract class TestCase extends \MediaWikiTestCase {
+abstract class TestCase extends MediaWikiIntegrationTestCase  {
 	protected function setUp(): void
 	{
 		parent::setUp();


### PR DESCRIPTION
---
Re-opened a PR with cleaner code and less bugs.
https://github.com/bovender/LinkTitles/pull/78#issuecomment-3056856826
---

I was getting this error:
TypeError: LinkTitles\Targets::singleton(): Argument https://github.com/bovender/LinkTitles/issues/1 ($title) must be of type Title, MediaWiki\Title\Title given, called in /var/www/html/extensions/LinkTitles/includes/Linker.php on line 83.

This was happening after updating to Mediawiki release REL1_44.

This fix replaces the old \Title references with the new \MediaWiki\Title\Title.